### PR TITLE
CI badge, correct Julia requirement to 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3' # LTS
+          - '1.6' # LTS
           - '1'
 #          - 'nightly'
         os:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.3' # LTS
           - '1'
 #          - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "1.2.0"
 xsum_jll = "e979a739-315a-50ee-b437-b496a9503be1"
 
 [compat]
-julia = "1.3"
+julia = "1.6"
 xsum_jll = "2"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Xsum: Exactly rounded floating-point sums in Julia
+[![CI](https://github.com/JuliaMath/Xsum.jl/workflows/CI/badge.svg)](https://github.com/JuliaMath/Xsum.jl/actions?query=workflow%3ACI)
 
 The Xsum package is a Julia wrapper around Radford Neal's [xsum package](https://gitlab.com/radfordneal/xsum)
 for exactly rounded double-precision floating-point summation.  The [xsum algorithm](https://arxiv.org/abs/1505.05571) takes `n` double precision (`Float64` or smaller) floating-point values as input and computes the "exactly rounded sum" — equivalent to summing the values in *infinite* precision and rounding the result to the nearest `Float64` value.


### PR DESCRIPTION
Add CI badge to README

~~And test Julia 1.3 since that is the earliest supported version according to Project.toml~~ … Hmm, it seems that Julia 1.3 is not actually supported any more, since `xsum_jll` now requires Julia 1.6.   (Note that changing the `Project.toml` in this way does not actually affect downstream packages, since earlier versions of Julia could not install this version of Xsum anyway.)