### PR TITLE
Update xsum_jll to v3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ xsum_jll = "e979a739-315a-50ee-b437-b496a9503be1"
 
 [compat]
 julia = "1.6"
-xsum_jll = "2"
+xsum_jll = "3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Xsum"
 uuid = "1fd64df0-a4d2-11e9-360d-2f03868f4cf5"
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 xsum_jll = "e979a739-315a-50ee-b437-b496a9503be1"


### PR DESCRIPTION
Fix #15 

```
(Xsum) pkg> test
     Testing Xsum
      Status `/private/var/folders/t6/g4hn6yfs42gc9xf11bzk77200000gn/T/jl_SQkyal/Project.toml`
  [1fd64df0] Xsum v1.2.0 `~/Projects/Xsum.jl`
  [e979a739] xsum_jll v3.0.0+0
  [9a3f8284] Random v1.11.0
  [8dfed614] Test v1.11.0
      Status `/private/var/folders/t6/g4hn6yfs42gc9xf11bzk77200000gn/T/jl_SQkyal/Manifest.toml`
  [692b3bcd] JLLWrappers v1.7.0
  [21216c6a] Preferences v1.4.3
  [1fd64df0] Xsum v1.2.0 `~/Projects/Xsum.jl`
  [e979a739] xsum_jll v3.0.0+0
  [56f22d72] Artifacts v1.11.0
  [2a0f44e3] Base64 v1.11.0
  [ade2ca70] Dates v1.11.0
  [b77e0a4c] InteractiveUtils v1.11.0
  [8f399da3] Libdl v1.11.0
  [56ddb016] Logging v1.11.0
  [d6f4376e] Markdown v1.11.0
  [de0858da] Printf v1.11.0
  [9a3f8284] Random v1.11.0
  [ea8e919c] SHA v0.7.0
  [9e88b42a] Serialization v1.11.0
  [fa267f1f] TOML v1.0.3
  [8dfed614] Test v1.11.0
  [4ec0a83e] Unicode v1.11.0
     Testing Running tests...
Test Summary: | Pass  Total  Time
xsum          |   12     12  0.6s
Test Summary: | Pass  Total  Time
XAccumulator  |   10     10  0.1s
     Testing Xsum tests passed 
```